### PR TITLE
refactor: migrate video upload to boto3 and fix S3 signature issues f…

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 from boto.s3.connection import S3Connection
 from boto import s3
+import boto3
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import FileResponse, HttpResponseNotFound, StreamingHttpResponse
@@ -824,32 +825,29 @@ def videos_post(course, request):
             return {'error': error_msg}, 400
 
         edx_video_id = str(uuid4())
-        key = storage_service_key(bucket, file_name=edx_video_id)
-
-        metadata_list = [
-            ('client_video_id', file_name),
-            ('course_key', str(course.id)),
-        ]
-
-        course_video_upload_token = course.video_upload_pipeline.get('course_video_upload_token')
-
-        # Only include `course_video_upload_token` if youtube has not been deprecated
-        # for this course.
-        if not DEPRECATE_YOUTUBE.is_enabled(course.id) and course_video_upload_token:
-            metadata_list.append(('course_video_upload_token', course_video_upload_token))
-
-        is_video_transcript_enabled = VideoTranscriptEnabledFlag.feature_enabled(course.id)
-        if is_video_transcript_enabled:
-            transcript_preferences = get_transcript_preferences(str(course.id))
-            if transcript_preferences is not None:
-                metadata_list.append(('transcript_preferences', json.dumps(transcript_preferences)))
-
-        for metadata_name, value in metadata_list:
-            key.set_metadata(metadata_name, value)
-        upload_url = key.generate_url(
-            KEY_EXPIRATION_IN_SECONDS,
-            'PUT',
-            headers={'Content-Type': req_file['content_type']}
+        
+        # Use boto3 to generate presigned URL without metadata
+        # Metadata is not needed on S3 object since VAL stores all video info in DB
+        s3_client = boto3.client(
+            's3',
+            region_name='ap-south-1',
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        )
+        
+        key_name = "{}/{}".format(
+            settings.VIDEO_UPLOAD_PIPELINE.get("ROOT_PATH", ""),
+            edx_video_id
+        )
+        
+        # Generate presigned URL without metadata to avoid signature mismatch
+        upload_url = s3_client.generate_presigned_url(
+            'put_object',
+            Params={
+                'Bucket': settings.VIDEO_UPLOAD_PIPELINE['BUCKET'],
+                'Key': key_name
+            },
+            ExpiresIn=KEY_EXPIRATION_IN_SECONDS
         )
 
         # persist edx_video_id in VAL
@@ -884,7 +882,8 @@ def storage_service_bucket():
             'aws_secret_access_key': settings.AWS_SECRET_ACCESS_KEY
         }
 
-    conn = S3Connection(**params)
+    # Force signature version 4 for regions outside us-east-1
+    conn = S3Connection(host='s3.ap-south-1.amazonaws.com', **params)
 
     # We don't need to validate our bucket, it requires a very permissive IAM permission
     # set since behind the scenes it fires a HEAD request that is equivalent to get_all_keys()
@@ -908,12 +907,25 @@ def send_video_status_update(updates):
     """
     Update video status in edx-val.
     """
+    mark_ready_on_completion = settings.VIDEO_UPLOAD_PIPELINE.get('MARK_READY_ON_UPLOAD_COMPLETE', False)
+
     for update in updates:
-        update_video_status(update.get('edxVideoId'), update.get('status'))
+        edx_video_id = update.get('edxVideoId')
+        status = update.get('status')
+
+        update_video_status(edx_video_id, status)
+
+        if mark_ready_on_completion and status == 'upload_completed':
+            update_video_status(edx_video_id, 'file_complete')
+            LOGGER.info(
+                'VIDEOS: Auto-advancing video status to [file_complete] for id [%s]',
+                edx_video_id
+            )
+
         LOGGER.info(
             'VIDEOS: Video status update with id [%s], status [%s] and message [%s]',
-            update.get('edxVideoId'),
-            update.get('status'),
+            edx_video_id,
+            status,
             update.get('message')
         )
 

--- a/openedx/core/djangoapps/user_api/accounts/image_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/image_helpers.py
@@ -2,7 +2,6 @@
 Helper functions for the accounts API.
 """
 
-
 import hashlib
 
 from django.conf import settings
@@ -15,19 +14,23 @@ from common.djangoapps.student.models import UserProfile
 
 from ..errors import UserNotFound
 
-PROFILE_IMAGE_FILE_EXTENSION = 'jpg'   # All processed profile images are converted to JPEGs
+PROFILE_IMAGE_FILE_EXTENSION = (
+    "jpg"  # All processed profile images are converted to JPEGs
+)
 
 _PROFILE_IMAGE_SIZES = list(settings.PROFILE_IMAGE_SIZES_MAP.values())
 
 
 def get_profile_image_storage():
-    """
+    """\
     Configures and returns a django Storage instance that can be used
     to physically locate, read and write profile images.
     """
     config = settings.PROFILE_IMAGE_BACKEND
-    storage_class = get_storage_class(config['class'])
-    return storage_class(**config['options'])
+    storage_class = get_storage_class(config["class"])
+    options = dict(config.get("options", {}))
+    options.pop("base_url", None)
+    return storage_class(**options)
 
 
 def _make_profile_image_name(username):
@@ -36,21 +39,26 @@ def _make_profile_image_name(username):
     the username.
     """
     hash_input = settings.PROFILE_IMAGE_HASH_SEED + username
-    return hashlib.md5(hash_input.encode('utf-8')).hexdigest()
+    return hashlib.md5(hash_input.encode("utf-8")).hexdigest()
 
 
-def _get_profile_image_filename(name, size, file_extension=PROFILE_IMAGE_FILE_EXTENSION):
+def _get_profile_image_filename(
+    name, size, file_extension=PROFILE_IMAGE_FILE_EXTENSION
+):
     """
     Returns the full filename for a profile image, given the name and size.
     """
-    return f'{name}_{size}.{file_extension}'
+    return f"{name}_{size}.{file_extension}"
 
 
-def _get_profile_image_urls(name, storage, file_extension=PROFILE_IMAGE_FILE_EXTENSION, version=None):
+def _get_profile_image_urls(
+    name, storage, file_extension=PROFILE_IMAGE_FILE_EXTENSION, version=None
+):
     """
     Returns a dict containing the urls for a complete set of profile images,
     keyed by "friendly" name (e.g. "full", "large", "medium", "small").
     """
+
     def _make_url(size):
         url = storage.url(
             _get_profile_image_filename(name, size, file_extension=file_extension)
@@ -59,10 +67,13 @@ def _get_profile_image_urls(name, storage, file_extension=PROFILE_IMAGE_FILE_EXT
         # string with "?v=". If the original URL already includes a
         # query string (such as signed S3 URLs), append to the query
         # string with "&v=" instead.
-        separator = '&' if '?' in url else '?'
-        return f'{url}{separator}v={version}' if version is not None else url
+        separator = "&" if "?" in url else "?"
+        return f"{url}{separator}v={version}" if version is not None else url
 
-    return {size_display_name: _make_url(size) for size_display_name, size in settings.PROFILE_IMAGE_SIZES_MAP.items()}
+    return {
+        size_display_name: _make_url(size)
+        for size_display_name, size in settings.PROFILE_IMAGE_SIZES_MAP.items()
+    }
 
 
 def get_profile_image_names(username):
@@ -71,7 +82,9 @@ def get_profile_image_names(username):
     images, keyed by pixel size.
     """
     name = _make_profile_image_name(username)
-    return {size: _get_profile_image_filename(name, size) for size in _PROFILE_IMAGE_SIZES}
+    return {
+        size: _get_profile_image_filename(name, size) for size in _PROFILE_IMAGE_SIZES
+    }
 
 
 def get_profile_image_urls_for_user(user, request=None):
@@ -123,7 +136,9 @@ def _get_default_profile_image_urls():
     TODO The result of this function should be memoized, but not in tests.
     """
     return _get_profile_image_urls(
-        configuration_helpers.get_value('PROFILE_IMAGE_DEFAULT_FILENAME', settings.PROFILE_IMAGE_DEFAULT_FILENAME),
+        configuration_helpers.get_value(
+            "PROFILE_IMAGE_DEFAULT_FILENAME", settings.PROFILE_IMAGE_DEFAULT_FILENAME
+        ),
         staticfiles_storage,
         file_extension=settings.PROFILE_IMAGE_DEFAULT_FILE_EXTENSION,
     )


### PR DESCRIPTION
- Replace boto2 with boto3 for generating presigned upload URLs
- Remove S3 metadata from video uploads as VAL stores video info in DB
- Force S3 signature version 4 for ap-south-1 region compatibility
- Add auto-advance video status to file_complete when MARK_READY_ON_UPLOAD_COMPLETE is enabled
- Remove base_url from profile image storage options to prevent URL conflicts
- Apply code formatting improvements

