### PR TITLE
fix: show course price in its own currency on catalog about sidebar

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -928,6 +928,34 @@ def get_course_prices(course, verified_only=False):
     return registration_price, format_course_price(price)
 
 
+def get_course_display_price(course):
+    """
+    Return the course price using the paid mode's OWN currency (e.g. "₹1000"),
+    or 'Free' when there is no paid mode.
+
+    Unlike get_course_prices(), this does not force PAID_COURSE_REGISTRATION_CURRENCY,
+    so courses priced in any currency (INR, EUR, ...) display correctly instead of "Free".
+    """
+    from babel.numbers import get_currency_symbol
+
+    paid_mode = None
+    for mode in CourseMode.modes_for_course(course.id):
+        if mode.min_price and mode.min_price > 0:
+            if mode.slug == CourseMode.VERIFIED:
+                paid_mode = mode
+                break
+            if paid_mode is None:
+                paid_mode = mode
+
+    if not paid_mode:
+        # No paid mode: keep existing behaviour (handles cosmetic_display_price / "Free").
+        _, price = get_course_prices(course)
+        return price
+
+    symbol = get_currency_symbol((paid_mode.currency or 'usd').upper())
+    return f"{symbol}{paid_mode.min_price}"
+
+
 def format_course_price(price):
     """
     Return a formatted price for a course (a string preceded by correct currency, or 'Free').

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -25,7 +25,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
 from xmodule.modulestore.search import path_to_location
 from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
-from common.djangoapps.course_modes.models import CourseMode, get_course_prices
+from common.djangoapps.course_modes.models import CourseMode, get_course_prices, get_course_display_price
 from common.djangoapps.util.views import expose_header
 from lms.djangoapps.edxnotes.helpers import is_feature_enabled
 from lms.djangoapps.certificates.api import get_certificate_url
@@ -499,10 +499,9 @@ class CoursewareMeta:
     @property
     def course_price(self):
         """
-        Returns the course price, formatted with the currency symbol.
+        Returns the course price, formatted with the course mode's own currency symbol.
         """
-        _, course_price = get_course_prices(self.course)
-        return course_price
+        return get_course_display_price(self.course)
 
     @property
     def pre_requisite_courses(self):


### PR DESCRIPTION
## Summary
- Catalog About sidebar showed "Free" for paid non-USD courses because `get_course_prices()` forces `PAID_COURSE_REGISTRATION_CURRENCY` (USD) and falls back to "Free" on a currency mismatch.
- Added `get_course_display_price()` in `common/djangoapps/course_modes/models.py` that reads the course's own paid mode (verified preferred, else first paid mode) and formats `min_price` with that mode's own currency symbol via Babel.
- Wired it into `CoursewareMeta.course_price` (`courseware_api/views.py`). `get_course_prices()` is untouched for all other callers; genuinely free courses still return "Free".
## Behavior
- Paid USD course: `$1000` (unchanged)
- Paid INR/EUR/etc course: `₹1000` / `€40` (was "Free")
- Free course: "Free" (unchanged)
## Verified
- Catalog About sidebar shows correct currency+price for all the currencies.
- Free course shows "Free"