### PR TITLE
Rebrand/updated endpoint for catalog

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -237,7 +237,7 @@ class CourseDetailSerializer(CourseSerializer):  # pylint: disable=abstract-meth
         This maps to the CourseDetails "title" marketing field in Studio,
         which in this deployment is used to capture course requirements.
         """
-        return course_about.get_course_requirement(course_overview.id)
+        return course_about.sanitize_plain_text(self._get_about_attribute(course_overview, 'title'))
 
     def get_description(self, course_overview):
         """

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -16,6 +16,7 @@ from lms.djangoapps.certificates.api import can_show_certificate_available_date_
 from openedx.core.djangoapps.content.course_overviews.models import \
     CourseOverview  # lint-amnesty, pylint: disable=unused-import
 from openedx.core.djangoapps.models.course_details import CourseDetails
+from openedx.core.lib import course_about
 from openedx.core.lib.api.fields import AbsoluteURLField
 from xmodule.modulestore.django import modulestore
 
@@ -145,19 +146,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
         """
         Get the course duration from course details.
         """
-        course_details = self._get_cached_course_details(course_overview)
-        duration_value = getattr(course_details, "duration_value", None)
-        duration_unit = getattr(course_details, "duration_unit", None)
-        if course_details and duration_value and duration_unit:
-            value = duration_value
-            unit = duration_unit
-
-            # Singularize if needed
-            if value == 1 and unit.endswith("s"):
-                unit = unit[:-1]
-
-            return f"{value} {unit}"
-        return None
+        return course_about.get_course_duration(self._get_cached_course_details(course_overview))
 
     def _get_cached_course_details(self, course_overview):
         """
@@ -248,8 +237,7 @@ class CourseDetailSerializer(CourseSerializer):  # pylint: disable=abstract-meth
         This maps to the CourseDetails "title" marketing field in Studio,
         which in this deployment is used to capture course requirements.
         """
-        # Studio stores this value in the "title" about attribute; we expose it as Course Requirement.
-        return self._get_about_attribute(course_overview, 'title')
+        return course_about.get_course_requirement(course_overview.id)
 
     def get_description(self, course_overview):
         """
@@ -262,44 +250,18 @@ class CourseDetailSerializer(CourseSerializer):  # pylint: disable=abstract-meth
         """
         Return learning outcomes as a list of strings from CourseDetails.learning_info.
         """
-        course_details = self._get_cached_course_details(course_overview)
-        outcomes = getattr(course_details, 'learning_info', None) if course_details else None
-        # Ensure we only return list[str] or None
-        if isinstance(outcomes, (list, tuple)):
-            return [o for o in outcomes if isinstance(o, str)]
-        return None
+        return course_about.get_course_learning_outcomes(
+            self._get_cached_course_details(course_overview)
+        ) or None
 
     def get_instructors(self, course_overview):
         """
-        Return instructor details excluding media. Each item includes
-        name, title, organization, and bio.
+        Return instructor details including name, title, organization, bio and image.
         """
-        course_details = self._get_cached_course_details(course_overview)
-        instructor_info = getattr(course_details, 'instructor_info', None) if course_details else None
-        instructors = []
         request = self.context.get('request') if self.context else None
-        absolute_url_field = AbsoluteURLField() if request else None
-        if absolute_url_field:
-            absolute_url_field._context = {'request': request}  # lint-amnesty, pylint: disable=protected-access
-        try:
-            raw_list = (instructor_info or {}).get('instructors', [])
-        except AttributeError:
-            raw_list = []
-        for ins in raw_list:
-            if not isinstance(ins, dict):
-                continue
-            image_url = ins.get('image')
-            if image_url:
-                if absolute_url_field:
-                    image_url = absolute_url_field.to_representation(image_url)
-            instructors.append({
-                'name': ins.get('name'),
-                'title': ins.get('title'),
-                'organization': ins.get('organization'),
-                'bio': ins.get('bio'),
-                'image': image_url,
-            })
-        return instructors or None
+        return course_about.get_course_instructors(
+            self._get_cached_course_details(course_overview), request
+        ) or None
 
     def get_purchase_link(self, course_overview):
         """

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -81,6 +81,17 @@ class PrerequisiteCourseSerializer(serializers.Serializer):
     display = serializers.CharField()
 
 
+class InstructorSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Serializer for a single course instructor.
+    """
+    name = serializers.CharField(allow_blank=True, allow_null=True, default='')
+    title = serializers.CharField(allow_blank=True, allow_null=True, default='')
+    organization = serializers.CharField(allow_blank=True, allow_null=True, default='')
+    image = serializers.CharField(allow_blank=True, allow_null=True, default='')
+    bio = serializers.CharField(allow_blank=True, allow_null=True, default='')
+
+
 class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     """
     Serializer for Course objects providing minimal data about the course.
@@ -155,6 +166,42 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     display_number_with_default = serializers.CharField()
     display_org_with_default = serializers.CharField()
     overview = serializers.CharField(
+        allow_blank=True,
+        allow_null=True,
+        default=None,
+    )
+    description = serializers.CharField(
+        allow_blank=True,
+        allow_null=True,
+        default=None,
+    )
+    learning_info = serializers.ListField(
+        child=serializers.CharField(),
+        allow_empty=True,
+        default=list,
+    )
+    instructor_info = serializers.ListField(
+        child=InstructorSerializer(),
+        allow_empty=True,
+        default=list,
+    )
+    duration = serializers.CharField(
+        allow_blank=True,
+        allow_null=True,
+        default=None,
+    )
+    enrolled_students_count = serializers.IntegerField(default=0)
+    requirements = serializers.CharField(
+        allow_blank=True,
+        allow_null=True,
+        default=None,
+    )
+    prerequisites = serializers.CharField(
+        allow_blank=True,
+        allow_null=True,
+        default=None,
+    )
+    ocw_links = serializers.CharField(
         allow_blank=True,
         allow_null=True,
         default=None,

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -516,15 +516,21 @@ class CoursewareMeta:
         """
         return get_prerequisite_courses_display(self.course)
 
+    def _get_about_section(self, section_key):
+        """
+        Returns the sanitized HTML content for the given course about section key.
+        """
+        return clean_dangerous_html(
+            get_course_about_section(self.request, self.course, section_key)
+        )
+
     @property
     def about_sidebar_html(self):
         """
         Returns the HTML content for the course about section.
         """
         if ENABLE_COURSE_ABOUT_SIDEBAR_HTML.is_enabled():
-            return clean_dangerous_html(
-                get_course_about_section(self.request, self.course, "about_sidebar_html")
-            )
+            return self._get_about_section("about_sidebar_html")
         return None
 
     @property
@@ -532,18 +538,14 @@ class CoursewareMeta:
         """
         Returns the overview HTML content for the course.
         """
-        return clean_dangerous_html(
-            get_course_about_section(self.request, self.course, "overview")
-        )
+        return self._get_about_section("overview")
 
     @property
     def description(self):
         """
         Returns the long description HTML content for the course.
         """
-        return clean_dangerous_html(
-            get_course_about_section(self.request, self.course, "description")
-        )
+        return self._get_about_section("description")
 
     @property
     def learning_info(self):
@@ -586,18 +588,14 @@ class CoursewareMeta:
         """
         Returns the course prerequisites HTML content, if set.
         """
-        return clean_dangerous_html(
-            get_course_about_section(self.request, self.course, "prerequisites")
-        )
+        return self._get_about_section("prerequisites")
 
     @property
     def ocw_links(self):
         """
         Returns the OCW (OpenCourseWare) additional-resources HTML content, if set.
         """
-        return clean_dangerous_html(
-            get_course_about_section(self.request, self.course, "ocw_links")
-        )
+        return self._get_about_section("ocw_links")
 
 
 @method_decorator(transaction.non_atomic_requests, name='dispatch')

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -66,6 +66,12 @@ from openedx.core.djangoapps.programs.utils import ProgramProgressMeter
 from openedx.core.djangolib.markup import clean_dangerous_html
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
+from openedx.core.lib.course_about import (
+    get_course_duration,
+    get_course_instructors,
+    get_course_learning_outcomes,
+    get_course_requirement,
+)
 from openedx.core.lib.courses import get_course_by_id
 from openedx.features.course_experience import ENABLE_COURSE_GOALS
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
@@ -530,6 +536,69 @@ class CoursewareMeta:
             get_course_about_section(self.request, self.course, "overview")
         )
 
+    @property
+    def description(self):
+        """
+        Returns the long description HTML content for the course.
+        """
+        return clean_dangerous_html(
+            get_course_about_section(self.request, self.course, "description")
+        )
+
+    @property
+    def learning_info(self):
+        """
+        Returns the list of learning outcomes ("what you will learn") for the course.
+        """
+        return get_course_learning_outcomes(self.course)
+
+    @property
+    def instructor_info(self):
+        """
+        Returns the list of instructors for the course, normalized to a list of dicts
+        each containing name, title, organization, image and bio.
+        """
+        return get_course_instructors(self.course, self.request)
+
+    @property
+    def duration(self):
+        """
+        Returns the estimated course duration (e.g. "6 weeks"), if set.
+        """
+        return get_course_duration(self.course)
+
+    @property
+    def enrolled_students_count(self):
+        """
+        Returns the number of students enrolled in the course, excluding admins.
+        """
+        return CourseEnrollment.objects.num_enrolled_in_exclude_admins(self.course_key)
+
+    @property
+    def requirements(self):
+        """
+        Returns the course requirements text (the extended "marketing" course title).
+        """
+        return get_course_requirement(self.course.id)
+
+    @property
+    def prerequisites(self):
+        """
+        Returns the course prerequisites HTML content, if set.
+        """
+        return clean_dangerous_html(
+            get_course_about_section(self.request, self.course, "prerequisites")
+        )
+
+    @property
+    def ocw_links(self):
+        """
+        Returns the OCW (OpenCourseWare) additional-resources HTML content, if set.
+        """
+        return clean_dangerous_html(
+            get_course_about_section(self.request, self.course, "ocw_links")
+        )
+
 
 @method_decorator(transaction.non_atomic_requests, name='dispatch')
 class CoursewareInformation(RetrieveAPIView):
@@ -657,6 +726,14 @@ class CoursewareInformation(RetrieveAPIView):
             * visible: Boolean indicating whether notes are visible in the course
         * marketing_url: The marketing URL for the course
         * overview: The overview HTML content for the course
+        * description: The long description HTML content for the course
+        * learning_info: A list of learning outcomes ("what you will learn") for the course
+        * instructor_info: A list of course instructors, each with name, title, organization, image and bio
+        * duration: The estimated course duration (e.g. "6 weeks")
+        * enrolled_students_count: The number of students enrolled in the course, excluding admins
+        * requirements: The course requirements text (the extended "marketing" course title)
+        * prerequisites: The course prerequisites HTML content
+        * ocw_links: The OCW additional-resources HTML content
         * license: The license for the course
 
     **Parameters:**

--- a/openedx/core/lib/course_about.py
+++ b/openedx/core/lib/course_about.py
@@ -8,17 +8,36 @@ suitable for serialization.
 
 They are shared by the multiple course-detail APIs (e.g. the courseware API used by
 the catalog MFE and the course API used by the mobile app) so that this logic lives
-in exactly one place. All author-entered HTML (instructor bios, learning outcomes,
-requirements) is passed through :func:`clean_dangerous_html` so that no endpoint
-can serve unsanitized markup.
+in exactly one place. All author-entered text (instructor bios, learning outcomes,
+requirements) has any HTML tags stripped before being returned, so no endpoint can
+serve unsanitized markup.
 """
 
 import logging
 
+import nh3
+
 from openedx.core.djangoapps.models.course_details import CourseDetails
-from openedx.core.djangolib.markup import clean_dangerous_html
 
 log = logging.getLogger(__name__)
+
+
+def sanitize_plain_text(text):
+    """
+    Strip any HTML tags from ``text`` without wrapping the remaining content in markup.
+
+    Unlike :func:`clean_dangerous_html` (which parses its input as an HTML document and
+    always emits well-formed HTML, e.g. wrapping bare text in ``<p>...</p>``), this is
+    for short, plain-text author fields (instructor names/bios, learning outcomes,
+    requirements) where the caller expects plain text back, not an HTML fragment.
+
+    Public so callers that already have their own cached/batched fetch for the raw
+    value (e.g. the course API's per-instance about-attribute cache) can sanitize it
+    without going through a second, uncached fetch.
+    """
+    if not text:
+        return text
+    return nh3.clean(text, tags=set())
 
 
 def get_course_instructors(course, request=None):
@@ -62,7 +81,7 @@ def get_course_instructors(course, request=None):
             'title': instructor.get('title') or '',
             'organization': instructor.get('organization') or '',
             'image': image or '',
-            'bio': clean_dangerous_html(instructor.get('bio')) or '',
+            'bio': sanitize_plain_text(instructor.get('bio')) or '',
         })
     return instructors
 
@@ -84,7 +103,7 @@ def get_course_learning_outcomes(course):
 
     outcomes = getattr(course, 'learning_info', []) or []
     return [
-        clean_dangerous_html(outcome)
+        sanitize_plain_text(outcome)
         for outcome in outcomes
         if isinstance(outcome, str) and outcome.strip()
     ]
@@ -130,4 +149,4 @@ def get_course_requirement(course_key):
     Returns:
         str or None: The sanitized requirements text, or ``None`` when it is not set.
     """
-    return clean_dangerous_html(CourseDetails.fetch_about_attribute(course_key, 'title'))
+    return sanitize_plain_text(CourseDetails.fetch_about_attribute(course_key, 'title'))

--- a/openedx/core/lib/course_about.py
+++ b/openedx/core/lib/course_about.py
@@ -1,0 +1,124 @@
+"""
+Shared helpers for extracting and normalizing course "about" / marketing details.
+
+These helpers read author-entered data off a course block (``instructor_info``,
+``learning_info``, ``duration_value``/``duration_unit``) or the course's "about"
+documents (the marketing ``title``), and return them in a normalized, safe shape
+suitable for serialization.
+
+They are shared by the multiple course-detail APIs (e.g. the courseware API used by
+the catalog MFE and the course API used by the mobile app) so that this logic lives
+in exactly one place. All author-entered HTML (instructor bios, learning outcomes,
+requirements) is passed through :func:`clean_dangerous_html` so that no endpoint
+can serve unsanitized markup.
+"""
+
+from openedx.core.djangoapps.models.course_details import CourseDetails
+from openedx.core.djangolib.markup import clean_dangerous_html
+
+
+def get_course_instructors(course, request=None):
+    """
+    Return the course instructors as a normalized list of dicts.
+
+    Each returned dict contains ``name``, ``title``, ``organization``, ``image`` and
+    ``bio``. Instructor bios are sanitized. When ``request`` is provided, relative
+    image paths (e.g. ``/asset-v1:.../photo.jpg``) are resolved to absolute URLs so
+    they load correctly from clients served on a different origin than the LMS.
+
+    Args:
+        course: The course block (may be ``None``).
+        request: The current request, used to build absolute image URLs. Optional.
+
+    Returns:
+        list[dict]: One dict per valid instructor. Empty list if there are none.
+    """
+    if course is None:
+        return []
+
+    info = getattr(course, 'instructor_info', {}) or {}
+    raw_instructors = info.get('instructors', []) if isinstance(info, dict) else []
+
+    instructors = []
+    for instructor in raw_instructors:
+        if not isinstance(instructor, dict):
+            continue
+
+        image = instructor.get('image')
+        if image and request is not None and not image.startswith(('http://', 'https://')):
+            image = request.build_absolute_uri(image)
+
+        instructors.append({
+            'name': instructor.get('name'),
+            'title': instructor.get('title'),
+            'organization': instructor.get('organization'),
+            'image': image,
+            'bio': clean_dangerous_html(instructor.get('bio')),
+        })
+    return instructors
+
+
+def get_course_learning_outcomes(course):
+    """
+    Return the course learning outcomes ("what you will learn") as a list of strings.
+
+    Blank entries are dropped and each entry is sanitized.
+
+    Args:
+        course: The course block (may be ``None``).
+
+    Returns:
+        list[str]: The learning outcomes. Empty list if there are none.
+    """
+    if course is None:
+        return []
+
+    outcomes = getattr(course, 'learning_info', []) or []
+    return [
+        clean_dangerous_html(outcome)
+        for outcome in outcomes
+        if isinstance(outcome, str) and outcome.strip()
+    ]
+
+
+def get_course_duration(course):
+    """
+    Return a human-readable course duration (e.g. ``"6 weeks"``), or ``None``.
+
+    The duration is built from the course's ``duration_value`` and ``duration_unit``
+    fields, singularizing the unit when the value is 1 (e.g. ``"1 week"``).
+
+    Args:
+        course: The course block (may be ``None``).
+
+    Returns:
+        str or None: The formatted duration, or ``None`` when it is not set.
+    """
+    if course is None:
+        return None
+
+    duration_value = getattr(course, 'duration_value', None)
+    duration_unit = getattr(course, 'duration_unit', None)
+    if duration_value and duration_unit:
+        unit = duration_unit
+        # Singularize the unit for a single-value duration (e.g. "1 week", not "1 weeks").
+        if duration_value == 1 and unit.endswith('s'):
+            unit = unit[:-1]
+        return f"{duration_value} {unit}"
+    return None
+
+
+def get_course_requirement(course_key):
+    """
+    Return the course requirements text, or ``None``.
+
+    In this deployment the "Course Requirements" content is stored in the marketing
+    ``title`` "about" attribute in Studio. The value is sanitized before being returned.
+
+    Args:
+        course_key: The course key (``CourseKey``).
+
+    Returns:
+        str or None: The sanitized requirements text, or ``None`` when it is not set.
+    """
+    return clean_dangerous_html(CourseDetails.fetch_about_attribute(course_key, 'title'))

--- a/openedx/core/lib/course_about.py
+++ b/openedx/core/lib/course_about.py
@@ -13,8 +13,12 @@ requirements) is passed through :func:`clean_dangerous_html` so that no endpoint
 can serve unsanitized markup.
 """
 
+import logging
+
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangolib.markup import clean_dangerous_html
+
+log = logging.getLogger(__name__)
 
 
 def get_course_instructors(course, request=None):
@@ -42,18 +46,23 @@ def get_course_instructors(course, request=None):
     instructors = []
     for instructor in raw_instructors:
         if not isinstance(instructor, dict):
+            log.warning(
+                "Skipping malformed instructor entry (expected dict, got %s) for course %s",
+                type(instructor).__name__, getattr(course, 'id', None),
+            )
             continue
 
         image = instructor.get('image')
+        image = image if isinstance(image, str) else None
         if image and request is not None and not image.startswith(('http://', 'https://')):
             image = request.build_absolute_uri(image)
 
         instructors.append({
-            'name': instructor.get('name'),
-            'title': instructor.get('title'),
-            'organization': instructor.get('organization'),
-            'image': image,
-            'bio': clean_dangerous_html(instructor.get('bio')),
+            'name': instructor.get('name') or '',
+            'title': instructor.get('title') or '',
+            'organization': instructor.get('organization') or '',
+            'image': image or '',
+            'bio': clean_dangerous_html(instructor.get('bio')) or '',
         })
     return instructors
 
@@ -99,7 +108,7 @@ def get_course_duration(course):
 
     duration_value = getattr(course, 'duration_value', None)
     duration_unit = getattr(course, 'duration_unit', None)
-    if duration_value and duration_unit:
+    if duration_value is not None and duration_unit:
         unit = duration_unit
         # Singularize the unit for a single-value duration (e.g. "1 week", not "1 weeks").
         if duration_value == 1 and unit.endswith('s'):

--- a/openedx/core/lib/tests/test_course_about.py
+++ b/openedx/core/lib/tests/test_course_about.py
@@ -1,0 +1,151 @@
+"""
+Tests for the shared course "about" / marketing detail helpers.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import TestCase
+
+from openedx.core.lib import course_about
+
+
+class _FakeRequest:
+    """Minimal request stub that resolves relative paths against a fixed host."""
+
+    def build_absolute_uri(self, location):
+        return f"http://lms.example.com{location}"
+
+
+def _course(**attrs):
+    """Build a lightweight stand-in for a course block with the given attributes."""
+    return SimpleNamespace(**attrs)
+
+
+class GetCourseInstructorsTests(TestCase):
+    """Tests for :func:`get_course_instructors`."""
+
+    def test_returns_empty_list_for_none_course(self):
+        self.assertEqual(course_about.get_course_instructors(None), [])
+
+    def test_returns_empty_list_when_not_configured(self):
+        self.assertEqual(course_about.get_course_instructors(_course(instructor_info={})), [])
+
+    def test_normalizes_instructor_fields(self):
+        course = _course(instructor_info={'instructors': [{
+            'name': 'Jane Doe',
+            'title': 'Professor',
+            'organization': 'openedX University',
+            'image': 'https://cdn.example.com/jane.jpg',
+            'bio': '<p>Bio</p>',
+        }]})
+
+        result = course_about.get_course_instructors(course)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'Jane Doe')
+        self.assertEqual(result[0]['title'], 'Professor')
+        self.assertEqual(result[0]['organization'], 'openedX University')
+
+    def test_resolves_relative_image_to_absolute_url(self):
+        course = _course(instructor_info={'instructors': [{'name': 'Jane', 'image': '/asset-v1:x/jane.jpg'}]})
+
+        result = course_about.get_course_instructors(course, _FakeRequest())
+
+        self.assertEqual(result[0]['image'], 'http://lms.example.com/asset-v1:x/jane.jpg')
+
+    def test_leaves_absolute_image_untouched(self):
+        course = _course(instructor_info={'instructors': [{'name': 'Jane', 'image': 'https://cdn/j.jpg'}]})
+
+        result = course_about.get_course_instructors(course, _FakeRequest())
+
+        self.assertEqual(result[0]['image'], 'https://cdn/j.jpg')
+
+    def test_leaves_relative_image_untouched_without_request(self):
+        course = _course(instructor_info={'instructors': [{'name': 'Jane', 'image': '/asset/j.jpg'}]})
+
+        result = course_about.get_course_instructors(course)
+
+        self.assertEqual(result[0]['image'], '/asset/j.jpg')
+
+    def test_sanitizes_instructor_bio(self):
+        course = _course(instructor_info={'instructors': [
+            {'name': 'Jane', 'bio': '<script>alert(1)</script><p>Safe</p>'},
+        ]})
+
+        result = course_about.get_course_instructors(course)
+
+        self.assertNotIn('<script>', result[0]['bio'])
+        self.assertIn('Safe', result[0]['bio'])
+
+    def test_skips_non_dict_entries(self):
+        course = _course(instructor_info={'instructors': ['not-a-dict', {'name': 'Jane'}]})
+
+        result = course_about.get_course_instructors(course)
+
+        self.assertEqual([i['name'] for i in result], ['Jane'])
+
+
+class GetCourseLearningOutcomesTests(TestCase):
+    """Tests for :func:`get_course_learning_outcomes`."""
+
+    def test_returns_empty_list_for_none_course(self):
+        self.assertEqual(course_about.get_course_learning_outcomes(None), [])
+
+    def test_filters_blank_and_non_string_entries(self):
+        course = _course(learning_info=['Learn X', '', '   ', None, 42, 'Learn Y'])
+
+        self.assertEqual(
+            course_about.get_course_learning_outcomes(course),
+            ['Learn X', 'Learn Y'],
+        )
+
+    def test_sanitizes_entries(self):
+        course = _course(learning_info=['<script>bad</script>keep'])
+
+        result = course_about.get_course_learning_outcomes(course)
+
+        self.assertNotIn('<script>', result[0])
+        self.assertIn('keep', result[0])
+
+
+class GetCourseDurationTests(TestCase):
+    """Tests for :func:`get_course_duration`."""
+
+    def test_returns_none_for_none_course(self):
+        self.assertIsNone(course_about.get_course_duration(None))
+
+    def test_returns_none_when_unset(self):
+        self.assertIsNone(course_about.get_course_duration(_course(duration_value=None, duration_unit=None)))
+
+    def test_formats_value_and_unit(self):
+        self.assertEqual(
+            course_about.get_course_duration(_course(duration_value=6, duration_unit='weeks')),
+            '6 weeks',
+        )
+
+    def test_singularizes_unit_for_value_of_one(self):
+        self.assertEqual(
+            course_about.get_course_duration(_course(duration_value=1, duration_unit='weeks')),
+            '1 week',
+        )
+
+
+class GetCourseRequirementTests(TestCase):
+    """Tests for :func:`get_course_requirement`."""
+
+    @mock.patch('openedx.core.lib.course_about.CourseDetails.fetch_about_attribute')
+    def test_fetches_and_sanitizes_title_attribute(self, mock_fetch):
+        mock_fetch.return_value = '<script>x</script><p>Requirement</p>'
+
+        result = course_about.get_course_requirement('course-v1:Org+Course+Run')
+
+        mock_fetch.assert_called_once_with('course-v1:Org+Course+Run', 'title')
+        self.assertNotIn('<script>', result)
+        self.assertIn('Requirement', result)
+
+    @mock.patch('openedx.core.lib.course_about.CourseDetails.fetch_about_attribute')
+    def test_returns_none_when_unset(self, mock_fetch):
+        mock_fetch.return_value = None
+
+        self.assertIsNone(course_about.get_course_requirement('course-v1:Org+Course+Run'))

--- a/openedx/core/lib/tests/test_course_about.py
+++ b/openedx/core/lib/tests/test_course_about.py
@@ -85,6 +85,13 @@ class GetCourseInstructorsTests(TestCase):
 
         self.assertEqual([i['name'] for i in result], ['Jane'])
 
+    def test_ignores_non_string_image(self):
+        course = _course(instructor_info={'instructors': [{'name': 'Jane', 'image': 42}]})
+
+        result = course_about.get_course_instructors(course, _FakeRequest())
+
+        self.assertEqual(result[0]['image'], '')
+
 
 class GetCourseLearningOutcomesTests(TestCase):
     """Tests for :func:`get_course_learning_outcomes`."""
@@ -128,6 +135,12 @@ class GetCourseDurationTests(TestCase):
         self.assertEqual(
             course_about.get_course_duration(_course(duration_value=1, duration_unit='weeks')),
             '1 week',
+        )
+
+    def test_formats_value_of_zero(self):
+        self.assertEqual(
+            course_about.get_course_duration(_course(duration_value=0, duration_unit='weeks')),
+            '0 weeks',
         )
 
 


### PR DESCRIPTION
- pulls out the course details logic (duration, instructors, requirements, learning outcomes) into one shared file instead of having it copy-pasted in two places
- adds the same course detail fields (description, instructors, duration, enrolled students count, requirements, prerequisites, extra resources) to the catalog website's api that the mobile app already had
- fixes a bug where a course with an image field that's not a normal text link could crash the whole course page instead of just skipping that one image
- fixes a bug where a course duration of 0 was being treated as if no duration was set at all
- cleans up so instructor fields show up as blank text instead of null when they're missing, so the frontend doesn't break on unexpected values
- adds a warning log if instructor data is broken/malformed, so it's easier to spot instead of silently disappearing
- simplifies repeated code for fetching course about-page sections (overview, description, prerequisites, etc) into one shared helper
- adds tests to cover the new shared logic